### PR TITLE
feat: configure metrics and add simple example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,12 @@ description = "OpenTelemetry Rust distribution for Uptrace"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-opentelemetry = { version = "0.18.0", features = ["trace", "rt-tokio"] }
+opentelemetry = { version = "0.18.0", features = ["metrics", "rt-tokio"] }
 thiserror = "1.0.38"
 url = "2.3.1"
 opentelemetry-otlp = { version = "0.11.0", features = [
     "tonic",
+    "metrics",
     "tls",
     "tls-roots",
 ] }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -13,8 +13,7 @@ async fn main() {
         .with_service_name("myservice")
         .with_service_version("1.0.0")
         .with_deployment_environment("testing")
-        .with_disable_metrics()
-        .install_simple()
+        .configure_opentelemetry()
         .unwrap();
 
     let tracer = global::tracer("app_or_crate_name");

--- a/examples/metrics.rs
+++ b/examples/metrics.rs
@@ -1,0 +1,23 @@
+use std::{thread, time::Duration};
+
+use opentelemetry::{global, Context};
+use uptrace::UptraceBuilder;
+
+#[tokio::main]
+async fn main() {
+    UptraceBuilder::new()
+        .with_service_name("myservice")
+        .with_service_version("1.0.0")
+        .with_deployment_environment("testing")
+        .configure_opentelemetry()
+        .unwrap();
+
+    let meter = global::meter("app_or_crate_name");
+    let histogram = meter.f64_histogram("ex.com.three").init();
+
+    let cx = Context::new();
+    for _i in 1..100000 {
+        histogram.record(&cx, 1.3, &[]);
+        thread::sleep(Duration::from_millis(100));
+    }
+}


### PR DESCRIPTION
I also took a chance to rename `install_simple` to `configure_opentelemetry` so it looks the same as in other distros.