### PR TITLE
chore: tweak API and update README with some code

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,53 @@ Run the [basic example](examples/basic.rs) below using the DSN from the Uptrace 
 ```shell
 UPTRACE_DSN=http://project2_secret_token@localhost:14317/2 cargo run --example basic
 ```
+
+```rust
+use std::{thread, time::Duration};
+
+use opentelemetry::{
+    global,
+    trace::{TraceContextExt, Tracer},
+    Key, KeyValue,
+};
+use uptrace::UptraceBuilder;
+
+#[tokio::main]
+async fn main() {
+    UptraceBuilder::new()
+        .with_service_name("myservice")
+        .with_service_version("1.0.0")
+        .with_deployment_environment("testing")
+        .configure_opentelemetry()
+        .unwrap();
+
+    let tracer = global::tracer("app_or_crate_name");
+
+    tracer.in_span("root-span", |cx| {
+        thread::sleep(Duration::from_millis(5));
+
+        tracer.in_span("GET /posts/:id", |cx| {
+            thread::sleep(Duration::from_millis(10));
+
+            let span = cx.span();
+            span.set_attribute(Key::new("http.method").string("GET"));
+            span.set_attribute(Key::new("http.route").string("/posts/:id"));
+            span.set_attribute(Key::new("http.url").string("http://localhost:8080/posts/123"));
+            span.set_attribute(Key::new("http.status_code").i64(200));
+        });
+
+        tracer.in_span("SELECT", |cx| {
+            thread::sleep(Duration::from_millis(20));
+
+            let span = cx.span();
+            span.set_attribute(KeyValue::new("db.system", "mysql"));
+            span.set_attribute(KeyValue::new("db.statement", "SELECT * FROM table"));
+        });
+
+        let span = cx.span();
+        println!("{:?}", span.span_context().trace_id().to_string());
+    });
+
+    global::shutdown_tracer_provider();
+}
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,8 @@ pub struct UptraceBuilder {
     service_version: Option<String>,
     deployment_environment: Option<String>,
 
-    disable_trace: bool,
-    disable_metrics: bool,
+    tracing_disabled: bool,
+    metrics_disabled: bool,
 }
 
 impl Default for UptraceBuilder {
@@ -74,8 +74,8 @@ impl Default for UptraceBuilder {
             service_version: None,
             deployment_environment: None,
 
-            disable_metrics: false,
-            disable_trace: false,
+            metrics_disabled: false,
+            tracing_disabled: false,
         }
     }
 }
@@ -127,16 +127,16 @@ impl UptraceBuilder {
         }
     }
 
-    pub fn with_disable_trace(self) -> Self {
+    pub fn with_tracing_disabled(self) -> Self {
         Self {
-            disable_trace: true,
+            tracing_disabled: true,
             ..self
         }
     }
 
-    pub fn with_disable_metrics(self) -> Self {
+    pub fn with_metrics_disabled(self) -> Self {
         Self {
-            disable_metrics: true,
+            metrics_disabled: true,
             ..self
         }
     }
@@ -151,11 +151,11 @@ impl UptraceBuilder {
             return Ok(());
         }
 
-        if !self.disable_trace {
+        if !self.tracing_disabled {
             self.init_tracing(&dsn)?;
         }
 
-        if !self.disable_metrics {
+        if !self.metrics_disabled {
             self.init_metrics(&dsn)?;
         }
 


### PR DESCRIPTION
This is a nitpick to rename `with_disable_metrics` to `with_metrics_disabled` which is what we use in other clients.